### PR TITLE
Add the system-ui font family

### DIFF
--- a/lib/variables/typography.scss
+++ b/lib/variables/typography.scss
@@ -25,7 +25,7 @@ $lh-condensed: 1.25 !default;
 $lh-default: 1.5 !default;
 
 // Font stacks
-$body-font: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol" !default;
+$body-font: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol" !default;
 
 // Monospace font stack
 $mono-font: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace !default;


### PR DESCRIPTION
Rationale for the addition: the -apple-system and BlinkMacSystemFont aliases work only in Mac OS; there appears to be a new standard, however, to make this functionality work across the board. The new name is system-ui, and it resolves e.g. to Segoe UI on Windows.

See also: https://www.chromestatus.com/feature/5640395337760768

This is incidentally consistent with the Bootstrap CSS framework: https://github.com/twbs/bootstrap/blob/v4-dev/scss/_variables.scss#L247
